### PR TITLE
Implement configurable release fast-forwarding

### DIFF
--- a/modules/release-ff/Configfile
+++ b/modules/release-ff/Configfile
@@ -1,0 +1,1 @@
+RELEASE_FF_BRANCH = $(shell cat RELEASE_FF_BRANCH)

--- a/modules/release-ff/Makefile
+++ b/modules/release-ff/Makefile
@@ -1,0 +1,7 @@
+include Configfile
+
+.PHONY: release-ff
+## Fast-forward from master branch to branch defined in RELEASE_FF_BRANCH file in the dev repo
+release-ff:
+	${BUILD_HARNESS_EXTENSIONS_PATH}/modules/release-ff/bin/release_ff.sh $(RELEASE_FF_BRANCH)
+

--- a/modules/release-ff/bin/release_ff.sh
+++ b/modules/release-ff/bin/release_ff.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+MASTER=master
+RELEASE_FF_BRANCH=$1
+
+if [[ -z "$RELEASE_FF_BRANCH" ]]
+then
+  echo "RELEASE_FF_BRANCH not set. Skipping fast-forward of release branch."
+  exit 0
+fi
+
+rm -rf repo-copy
+git clone -b ${MASTER} $(git remote get-url origin) repo-copy
+cd repo-copy
+if ! git checkout -b ${RELEASE_FF_BRANCH} origin/${RELEASE_FF_BRANCH}
+then
+  echo "Release branch does not exist. Creating new branch."
+  git checkout -b ${RELEASE_FF_BRANCH}
+  git push origin ${RELEASE_FF_BRANCH}
+else
+  git merge --ff-only ${MASTER}
+  git push
+fi


### PR DESCRIPTION
A participating repo should lay down a file named `RELEASE_FF_BRANCH` in the root of their project and have it contain the name of the branch of their repo they would like to fast-forward their changes from master into.