### PR TITLE
prevent unneeded errors from bubbling up

### DIFF
--- a/modules/deploy/Makefile
+++ b/modules/deploy/Makefile
@@ -1,1 +1,1 @@
-GIT:= $(shell which git)
+GIT:= $(shell which git 2> /dev/null)

--- a/modules/jq/Makefile
+++ b/modules/jq/Makefile
@@ -1,4 +1,4 @@
-CURL := $(shell which curl)
+CURL := $(shell which curl 2> /dev/null)
 TMP ?= /tmp
 JQ_VERSION ?= 1.5
 JQ_PLATFORM ?= $(shell echo $(BUILD_HARNESS_OS) | sed 's/darwin/osx-amd/g')

--- a/modules/retag/Makefile
+++ b/modules/retag/Makefile
@@ -1,5 +1,5 @@
-CURL := $(shell which curl)
-DOCKER := $(shell which docker)
+CURL := $(shell which curl 2> /dev/null)
+DOCKER := $(shell which docker 2> /dev/null)
 
 QUAY_TOKEN ?= 
 RETAG_DRY_RUN ?= false


### PR DESCRIPTION
These should not always report an error. If we do not need to use them, we do not need to know about the error. 

If we want to catch the error, we should check for existence of the commands before we try to use them so that we can present a useful error message.