### PR TITLE
Remove quiet parameter from Gosec Call

### DIFF
--- a/modules/sonar/Makefile
+++ b/modules/sonar/Makefile
@@ -2,7 +2,7 @@
 ## Run SonarCloud analysis for Go. This will generally be run as part of a Travis build, not during local development.
 sonar/go: go/gosec-install
 	go test -coverprofile=coverage.out -json ./... > report.json
-	gosec --quiet -fmt sonarqube -out gosec.json -no-fail ./...
+	gosec -fmt sonarqube -out gosec.json -no-fail ./...
 	unset SONARQUBE_SCANNER_PARAMS
 	sonar-scanner --debug
 


### PR DESCRIPTION
In the case that no potential vulnerabilities are found by Gosec, it will not create the gosec.json file that  sonar-scanner expects, causing the scanner to halt and consequently that rule will fail.

By removing the --quiet parameter, an empty issue array will be created in the gosec.json file so that things move on interrupted. 