### PR TITLE
Add ability to tag all repo elements with a version as well as snapshot name

### DIFF
--- a/modules/pipeline-manifest/Makefile
+++ b/modules/pipeline-manifest/Makefile
@@ -243,12 +243,21 @@ pipeline-manifest/_snapshot: %_snapshot: %_clone %_validate-tag
 	@cd $(PIPELINE_MANIFEST_DIR); $(GIT) push --quiet
 
 .PHONY: pipeline-manifest/_validate-tag
-# Validate all images identified in manifest exist in quay and create sha-based manifest
-pipeline-manifest/_validate-tag: %_validate-tag:
-	@python3 $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/parser.py $(PIPELINE_MANIFEST_FILE_NAME).json $(TAG) true $(PIPELINE_MANIFEST_RETAG_REPO)
-	@python3 $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/parser.py $(PIPELINE_MANIFEST_FILE_NAME).json $(TAG) false $(PIPELINE_MANIFEST_RETAG_REPO)
+# Validate all images or git repos identified in manifest exist and create sha-based manifest
+pipeline-manifest/_validate-tag: %_validate-tag: %_retag
 	@$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/decorate-manifest.sh $(PIPELINE_MANIFEST_FILE_NAME_V2).json $(PIPELINE_MANIFEST_FILE_NAME)-$(TAG)-$(PIPELINE_MANIFEST_SHA_RELEASE_VERSION).json $(PIPELINE_MANIFEST_ALIAS_FILE_NAME).json > out.tmp
 	@cat out.tmp
+
+.PHONY: pipeline-manifest/_retag
+# Validate and retag all images or git repos identified in manifest
+pipeline-manifest/_retag: %_retag:
+	@python3 $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/parser.py $(PIPELINE_MANIFEST_FILE_NAME).json $(TAG) true $(PIPELINE_MANIFEST_RETAG_REPO)
+	@python3 $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/parser.py $(PIPELINE_MANIFEST_FILE_NAME).json $(TAG) false $(PIPELINE_MANIFEST_RETAG_REPO)
+
+.PHONY: pipeline-manifest/_retag-test
+# Validate and retag all images or git repos identified in manifest
+pipeline-manifest/_retag-test: %_retag-test:
+	@python3 $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/parser.py $(PIPELINE_MANIFEST_FILE_NAME).json $(TAG) true $(PIPELINE_MANIFEST_RETAG_REPO)
 
 .PHONY: pipeline-manifest/_postprocess
 # Postprocessing steps

--- a/modules/pipeline-manifest/Makefile
+++ b/modules/pipeline-manifest/Makefile
@@ -254,11 +254,6 @@ pipeline-manifest/_retag: %_retag:
 	@python3 $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/parser.py $(PIPELINE_MANIFEST_FILE_NAME).json $(TAG) true $(PIPELINE_MANIFEST_RETAG_REPO)
 	@python3 $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/parser.py $(PIPELINE_MANIFEST_FILE_NAME).json $(TAG) false $(PIPELINE_MANIFEST_RETAG_REPO)
 
-.PHONY: pipeline-manifest/_retag-test
-# Validate and retag all images or git repos identified in manifest
-pipeline-manifest/_retag-test: %_retag-test:
-	@python3 $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/parser.py $(PIPELINE_MANIFEST_FILE_NAME).json $(TAG) true $(PIPELINE_MANIFEST_RETAG_REPO)
-
 .PHONY: pipeline-manifest/_postprocess
 # Postprocessing steps
 pipeline-manifest/_postprocess: %_postprocess:

--- a/modules/pipeline-manifest/bin/parser.py
+++ b/modules/pipeline-manifest/bin/parser.py
@@ -11,11 +11,18 @@ from subprocess import run
 
 data = json.load(open(sys.argv[1]))
 for v in data:
-    component_name = v["name"]
-    compenent_tag = v["tag"]
-    compenent_sha = v["sha256"]
-    component_repo = v["repository"]
-    component_version = v["tag"].replace('-'+v["sha256"],'')
+    try:
+        component_name = v["name"]
+        compenent_tag = v["tag"]
+        compenent_sha = v["sha256"]
+        component_repo = v["repository"]
+        component_version = v["tag"].replace('-'+v["sha256"],'')
+    except:
+        component_name = v["image-name"]
+        compenent_tag = v["image-tag"]
+        compenent_sha = v["git-sha256"]
+        component_repo = v["git-repository"]
+        component_version = v["image-tag"].replace('-'+v["sha256"],'')
     retag_name = component_version + "-SNAPSHOT-" + sys.argv[2]
     if (component_repo.startswith('open-cluster-management')):
       run('echo RETAG_SNAPSHOT_NAME={} COMPONENT_NAME={} RETAG_REPO={} RETAG_QUAY_COMPONENT_TAG={} RETAG_GITHUB_SHA={} RETAG_DRY_RUN={} repo-type={}'.format(retag_name, component_repo, component_name, compenent_tag, compenent_sha, sys.argv[3], sys.argv[4]), shell=True)

--- a/modules/pipeline-manifest/bin/parser.py
+++ b/modules/pipeline-manifest/bin/parser.py
@@ -22,7 +22,7 @@ for v in data:
         compenent_tag = v["image-tag"]
         compenent_sha = v["git-sha256"]
         component_repo = v["git-repository"]
-        component_version = v["image-tag"].replace('-'+v["sha256"],'')
+        component_version = v["image-tag"].replace('-'+v["git-sha256"],'')
     retag_name = component_version + "-SNAPSHOT-" + sys.argv[2]
     if (component_repo.startswith('open-cluster-management')):
       run('echo RETAG_SNAPSHOT_NAME={} COMPONENT_NAME={} RETAG_REPO={} RETAG_QUAY_COMPONENT_TAG={} RETAG_GITHUB_SHA={} RETAG_DRY_RUN={} repo-type={}'.format(retag_name, component_repo, component_name, compenent_tag, compenent_sha, sys.argv[3], sys.argv[4]), shell=True)

--- a/modules/pipeline-manifest/bin/parser.py
+++ b/modules/pipeline-manifest/bin/parser.py
@@ -12,21 +12,29 @@ from subprocess import run
 data = json.load(open(sys.argv[1]))
 for v in data:
     try:
+        # First, try manifest keys v1
         component_name = v["name"]
         compenent_tag = v["tag"]
         compenent_sha = v["sha256"]
         component_repo = v["repository"]
         component_version = v["tag"].replace('-'+v["sha256"],'')
     except:
+        # If that doesn't work, try manifest keys v2
         component_name = v["image-name"]
         compenent_tag = v["image-tag"]
         compenent_sha = v["git-sha256"]
         component_repo = v["git-repository"]
         component_version = v["image-tag"].replace('-'+v["git-sha256"],'')
-    retag_name = component_version + "-SNAPSHOT-" + sys.argv[2]
+    if (sys.argv[2].startswith('20')):
+        # Assuming a date is coming in as a tag, mark it all up with SNAPSHOT decoration specifc to this repo
+        retag_name = component_version + "-SNAPSHOT-" + sys.argv[2]
+    else:
+        # Tag is respected as literally and solely the second argument contents, likely a version/release tag
+        retag_name = sys.argv[2]
     if (component_repo.startswith('open-cluster-management')):
-      run('echo RETAG_SNAPSHOT_NAME={} COMPONENT_NAME={} RETAG_REPO={} RETAG_QUAY_COMPONENT_TAG={} RETAG_GITHUB_SHA={} RETAG_DRY_RUN={} repo-type={}'.format(retag_name, component_repo, component_name, compenent_tag, compenent_sha, sys.argv[3], sys.argv[4]), shell=True)
-      if (sys.argv[4] == "git"):
-          run('make retag/git RETAG_SNAPSHOT_NAME={} RETAG_REPO={} RETAG_QUAY_COMPONENT_TAG={} RETAG_GITHUB_SHA={} RETAG_DRY_RUN={}'.format(retag_name, component_repo, compenent_tag, compenent_sha, sys.argv[3]), shell=True, check=True)
-      elif (sys.argv[4] == "quay"):
-          run('make retag/quay RETAG_SNAPSHOT_NAME={} COMPONENT_NAME={} RETAG_QUAY_COMPONENT_TAG={} RETAG_GITHUB_SHA={} RETAG_DRY_RUN={}'.format(retag_name, component_name, compenent_tag, compenent_sha, sys.argv[3]), shell=True, check=True)
+        # We don't try to tag anyone else's repos
+        run('echo RETAG_SNAPSHOT_NAME={} COMPONENT_NAME={} RETAG_REPO={} RETAG_QUAY_COMPONENT_TAG={} RETAG_GITHUB_SHA={} RETAG_DRY_RUN={} repo-type={}'.format(retag_name, component_repo, component_name, compenent_tag, compenent_sha, sys.argv[3], sys.argv[4]), shell=True)
+        if (sys.argv[4] == "git"):
+            run('make retag/git RETAG_SNAPSHOT_NAME={} RETAG_REPO={} RETAG_QUAY_COMPONENT_TAG={} RETAG_GITHUB_SHA={} RETAG_DRY_RUN={}'.format(retag_name, component_repo, compenent_tag, compenent_sha, sys.argv[3]), shell=True, check=True)
+        elif (sys.argv[4] == "quay"):
+            run('make retag/quay RETAG_SNAPSHOT_NAME={} COMPONENT_NAME={} RETAG_QUAY_COMPONENT_TAG={} RETAG_GITHUB_SHA={} RETAG_DRY_RUN={}'.format(retag_name, component_name, compenent_tag, compenent_sha, sys.argv[3]), shell=True, check=True)

--- a/modules/pipeline-manifest/bin/postprocess.sh
+++ b/modules/pipeline-manifest/bin/postprocess.sh
@@ -38,5 +38,6 @@ else
 fi
 jq --arg ep_quaysha $ep_quaysha '(.[] | select (.["image-name"] == "endpoint-operator") | .["image-digest"]) |= $ep_quaysha' $manifest_filename > tmp.json ; mv tmp.json $manifest_filename
 jq --arg mco_quaysha $mco_quaysha '(.[] | select (.["image-name"] == "multiclusterhub-operator") | .["image-digest"]) |= $mco_quaysha' $manifest_filename > tmp.json ; mv tmp.json $manifest_filename
+if [[ "$ep_quaysha" == "null" || "$mco_quaysha" == "null" ]]; then echo Oh no - one of the operator image digests is missing!; exit 1; fi
 echo After, $manifest_filename is:
 cat $manifest_filename


### PR DESCRIPTION
We need the ability to tag everything in a (git) repo with a particular release tag, such as `v1.0` rather than individual components' versions and SNAPSHOT/date.  This gives us a particular target to call: `pipeline-manifest/_retag` to do just that.

Required to be specified:  
`PIPELINE_MANIFEST_FILE_NAME`  (without .json suffix)
`TAG` (if it starts with `20`, we assume it's a date and do the old-style decoration)
`PIPELINE_MANIFEST_RETAG_REPO` (literal text: `git` or `quay`)

The parser now accepts both v1 and v2 style manifests.