### PR TITLE
Support SONAR_GO_TEST_ARGS

### DIFF
--- a/modules/sonar/Makefile
+++ b/modules/sonar/Makefile
@@ -1,8 +1,8 @@
-GO_TEST_ARGS ?= ./...
+SONAR_GO_TEST_ARGS ?= ./...
 .PHONY: sonar/go
 ## Run SonarCloud analysis for Go. This will generally be run as part of a Travis build, not during local development.
 sonar/go: go/gosec-install
-	go test -coverprofile=coverage.out -json ${GO_TEST_ARGS} > report.json
+	go test -coverprofile=coverage.out -json ${SONAR_GO_TEST_ARGS} > report.json
 	gosec -fmt sonarqube -out gosec.json -no-fail ./...
 	unset SONARQUBE_SCANNER_PARAMS
 	sonar-scanner --debug

--- a/modules/sonar/Makefile
+++ b/modules/sonar/Makefile
@@ -1,7 +1,8 @@
+GO_TEST_ARGS ?= ./...
 .PHONY: sonar/go
 ## Run SonarCloud analysis for Go. This will generally be run as part of a Travis build, not during local development.
 sonar/go: go/gosec-install
-	go test -coverprofile=coverage.out -json ./... > report.json
+	go test -coverprofile=coverage.out -json ${GO_TEST_ARGS} > report.json
 	gosec -fmt sonarqube -out gosec.json -no-fail ./...
 	unset SONARQUBE_SCANNER_PARAMS
 	sonar-scanner --debug


### PR DESCRIPTION
use below env to skip `test/e2e` package.
```
export SONAR_GO_TEST_ARGS="\`go list ./... | grep -v test/e2e\`"
``` 
This allow us removing the `// +build integration` tag in e2e source file.

Because tag is cause e2e/test package not being built and can't debug in vscode