### PR TITLE
Add ability to find the latest manifest for a given release and branch

### DIFF
--- a/modules/pipeline-manifest/Makefile
+++ b/modules/pipeline-manifest/Makefile
@@ -222,6 +222,7 @@ pipeline-manifest/_retag: %_retag:
 .PHONY: pipeline-manifest/_get_latest_manifest
 # Get the latest manifest file in the snapshots directory of the pipeline repo on the PIPELINE_MANIFEST_LATEST_BRANCH branch (i.e. x.y-edge or x.y-stable) specific to a Z-release
 pipeline-manifest/_get_latest_manifest:
+	@$(shell $(SELF) jq/install > /dev/null)
 	@$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/get-latest-manifest.sh $(PIPELINE_MANIFEST_LATEST_BRANCH) $(PIPELINE_MANIFEST_LATEST_Z_RELEASE)
 
 .PHONY: pipeline-manifest/_postprocess

--- a/modules/pipeline-manifest/Makefile
+++ b/modules/pipeline-manifest/Makefile
@@ -29,7 +29,10 @@ PIPELINE_MANIFEST_ALIAS_FILE_NAME ?=image-alias
 PIPELINE_MANIFEST_SNAPSHOT_FOLDER ?= snapshots
 # The branch of the pipeline to use for quay retagging (typically quay-retag vs. quay-retag-test)
 PIPELINE_MANIFEST_RETAG_BRANCH ?= quay-retag
-
+# The branch of the pipeline to use for grabbing the latest manifest file (typically x.y-edge or x.y-stable)
+PIPELINE_MANIFEST_LATEST_BRANCH ?= 2.0-edge
+# The Z release of the pipeline to use for grabbing the latest manifest file
+PIPELINE_MANIFEST_LATEST_Z_RELEASE ?= 2.0.0
 PIPELINE_MANIFEST_REMOTE_REPO ?= quay.io/open-cluster-management
 
 PIPELINE_MANIFEST_COMPONENT_SUFFIX ?= $(PIPELINE_MANIFEST_COMPONENT_SHA256)
@@ -215,6 +218,11 @@ pipeline-manifest/_validate-tag: %_validate-tag:
 pipeline-manifest/_retag: %_retag:
 	@python3 $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/parser.py $(PIPELINE_MANIFEST_FILE_NAME).json $(TAG) true $(PIPELINE_MANIFEST_RETAG_REPO) $(PIPELINE_MANIFEST_SHA_RELEASE_VERSION)
 	@python3 $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/parser.py $(PIPELINE_MANIFEST_FILE_NAME).json $(TAG) false $(PIPELINE_MANIFEST_RETAG_REPO) $(PIPELINE_MANIFEST_SHA_RELEASE_VERSION)
+
+.PHONY: pipeline-manifest/_get_latest_manifest
+# Get the latest manifest file in the snapshots directory of the pipeline repo on the PIPELINE_MANIFEST_LATEST_BRANCH branch (i.e. x.y-edge or x.y-stable) specific to a Z-release
+pipeline-manifest/_get_latest_manifest:
+	@$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/get-latest-manifest.sh $(PIPELINE_MANIFEST_LATEST_BRANCH) $(PIPELINE_MANIFEST_LATEST_Z_RELEASE)
 
 .PHONY: pipeline-manifest/_postprocess
 # Postprocessing steps

--- a/modules/pipeline-manifest/bin/get-latest-manifest.sh
+++ b/modules/pipeline-manifest/bin/get-latest-manifest.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Incoming variables:
+#   $1 - name of the branch to get snapshots from (typically x.y-edge or x.y-stable)
+#   $2 - the Z release desired (i.e. 1.0.1, 2.0.1)
+#
+# Required environment variable:
+#   $GITHUB_TOKEN - the token.  To github.
+
+PIPELINE_MANIFEST_LATEST_BRANCH=$1
+PIPELINE_MANIFEST_LATEST_Z_RELEASE=$2
+
+OUTPUT=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/open-cluster-management/pipeline/git/trees/$PIPELINE_MANIFEST_LATEST_BRANCH?recursive=1")
+LATEST=`echo $OUTPUT | jq -r --arg PIPELINE_MANIFEST_LATEST_Z_RELEASE $PIPELINE_MANIFEST_LATEST_Z_RELEASE '[.tree[] | select(.path | contains("snapshots")) | select(.path | contains($PIPELINE_MANIFEST_LATEST_Z_RELEASE))] | .[-1].path'`
+
+BASENAME=`basename $LATEST`
+echo $BASENAME
+
+$(curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.raw" https://raw.githubusercontent.com/open-cluster-management/pipeline/$PIPELINE_MANIFEST_LATEST_BRANCH/$LATEST --output $BASENAME)
+


### PR DESCRIPTION
As a convenience - add the ability to dig out the "latest" manifest from snapshots from a given branch and release