### PR TITLE
Vendorize the Kubeconfig used in the oc module to prevent Kubeconfig polluiton.

### DIFF
--- a/modules/clusterpool/Makefile
+++ b/modules/clusterpool/Makefile
@@ -216,6 +216,12 @@ clusterpool/list-clusterimagesets: %list-clusterimagesets: %_init
 	$(call assert-set,CLUSTERPOOL_HOST_NAMESPACE)
 	@$(SELF) -s oc/command OC_COMMAND="get clusterimageset $(CLUSTERPOOL_LIST_ARGUMENTS)"
 
+.PHONY: clusterpool/list-clusterdeployments
+## List all clusterimagesets in the CLUSTERPOOL_HOST_NAMESPACE
+clusterpool/list-clusterdeployments: %list-clusterdeployments: %_init
+	$(call assert-set,CLUSTERPOOL_HOST_NAMESPACE)
+	@$(SELF) -s oc/command OC_COMMAND="get clusterdeployments --all-namespaces $(CLUSTERPOOL_LIST_ARGUMENTS)"
+
 .PHONY: clusterpool/aws/create-creds
 ## Create a hive credentials secret for AWS with input credentials
 clusterpool/aws/create-creds: %aws/create-creds: %_init

--- a/modules/oc/Makefile
+++ b/modules/oc/Makefile
@@ -15,6 +15,7 @@ OC_COMMAND ?=
 OC_LOGGED_IN ?= $(OC_DEST_PATH)/.oc_cli_logged_in
 OC_FORCE_LOGIN ?= 
 OC_SILENT ?= true
+OC_VENDORIZED_KUBECONFIG=$(OC_DEST_PATH)/kubeconfig
 
 .PHONY: oc/install
 ## Install the oc cli
@@ -36,16 +37,16 @@ oc/install: %install:
 oc/login: %login: %install
 	@if [ ! -z "$(OC_FORCE_LOGIN)" ] || [ ! -e "$(OC_LOGGED_IN)" ]; then \
 		if [ ! -z "$(OC_SILENT)" ]; then \
-			$(OC) login $(OC_CLUSTER_URL) $(OC_LOGIN_OPTIONS) -u $(OC_CLUSTER_USER) -p $(OC_CLUSTER_PASS) > /dev/null && touch $(OC_LOGGED_IN); \
+			KUBECONFIG=$(OC_VENDORIZED_KUBECONFIG) $(OC) login $(OC_CLUSTER_URL) $(OC_LOGIN_OPTIONS) -u $(OC_CLUSTER_USER) -p $(OC_CLUSTER_PASS) > /dev/null && touch $(OC_LOGGED_IN); \
 		else \
-			$(OC) login $(OC_CLUSTER_URL) $(OC_LOGIN_OPTIONS) -u $(OC_CLUSTER_USER) -p $(OC_CLUSTER_PASS) && touch $(OC_LOGGED_IN); \
+			KUBECONFIG=$(OC_VENDORIZED_KUBECONFIG) $(OC) login $(OC_CLUSTER_URL) $(OC_LOGIN_OPTIONS) -u $(OC_CLUSTER_USER) -p $(OC_CLUSTER_PASS) && touch $(OC_LOGGED_IN); \
 		fi; \
 	fi;
 
 .PHONY: oc/command
 ## Run $(OC_COMMAND) from CLI
 oc/command: %command: %install %login
-	$(OC) $(OC_COMMAND) 
+	KUBECONFIG=$(OC_VENDORIZED_KUBECONFIG) $(OC) $(OC_COMMAND) 
 	@if [ "$(OC_COMMAND)" = "logout" ]; \
 	then rm -f $(OC_LOGGED_IN); \
 	fi


### PR DESCRIPTION
## Summary of Changes

This change will cause the `oc` module to use a kubeconfig in the vendor directory.  We've included a new helpful clusterpool target to capture the final consumer use-case of clusterpool (listing ClusterDeployments) now that the clusterpool module will no longer connect your global kubeconfig to the clusterpool host.  


## Motivation for Changes

These changes were spurred on by a recent incident where a build harness clusterpool target changed a user's primary kubecontext globally for their system during an ACM deploy.  The ACM deploy successfully retargetted to the clusterpool host and resulted in an unrecoverable conflict between hive running on the clusterpool host and the version of hive shipped with ACM.  This vendorized kubeconfig will prevent any future overwrites of the global kubeconfig/kubecontext by the clusterpool module.  