### PR TITLE
remove github token for bootstrap

### DIFF
--- a/bin/install-extensions.sh
+++ b/bin/install-extensions.sh
@@ -2,10 +2,7 @@
 export BUILD_HARNESS_EXTENSIONS_ORG=${1:-open-cluster-management}
 export BUILD_HARNESS_EXTENSIONS_PROJECT=${2:-build-harness-extensions}
 export BUILD_HARNESS_EXTENSIONS_BRANCH=${3:-master}
-export GITHUB_USER=${4}
-export GITHUB_TOKEN=${5}
-export GITHUB_REPO_SECRET="https://${GITHUB_USER}:${GITHUB_TOKEN}@"
-export GITHUB_REPO="github.com/${BUILD_HARNESS_EXTENSIONS_ORG}/${BUILD_HARNESS_EXTENSIONS_PROJECT}.git"
+export GITHUB_REPO="https://github.com/${BUILD_HARNESS_EXTENSIONS_ORG}/${BUILD_HARNESS_EXTENSIONS_PROJECT}.git"
 
 # Note - whatever the extension project's name, we're calling it 'build-harness-extensions'
 if [ -d "build-harness-extensions" ]; then
@@ -15,4 +12,4 @@ fi
 
 echo "Cloning ${GITHUB_REPO}#${BUILD_HARNESS_EXTENSIONS_BRANCH}..."
 # Note - whatever the extension project's name, we're calling it 'build-harness-extensions'
-git clone -b $BUILD_HARNESS_EXTENSIONS_BRANCH $GITHUB_REPO_SECRET$GITHUB_REPO build-harness-extensions
+git clone -b $BUILD_HARNESS_EXTENSIONS_BRANCH $GITHUB_REPO build-harness-extensions

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -3,8 +3,6 @@ export BUILD_HARNESS_ORG=${1:-cloudposse}
 export BUILD_HARNESS_PROJECT=${2:-build-harness}
 export BUILD_HARNESS_BRANCH=${3:-master}
 # These will need to be used if a private repo is going to be cloned
-export GITHUB_USER=${4}
-export GITHUB_TOKEN=${5}
 export GITHUB_REPO="https://github.com/${BUILD_HARNESS_ORG}/${BUILD_HARNESS_PROJECT}.git"
 
 if [ "$BUILD_HARNESS_PROJECT" ] && [ -d "$BUILD_HARNESS_PROJECT" ]; then

--- a/templates/Makefile.build-harness-bootstrap
+++ b/templates/Makefile.build-harness-bootstrap
@@ -16,10 +16,10 @@ export BUILD_HARNESS_EXTENSIONS_PATH ?= $(shell until [ -d "$(BUILD_HARNESS_EXTE
 ## Init build-harness
 init::
 	@echo $(shell date)
-	@curl --retry 5 --fail --silent --retry-delay 1 -H "Authorization: token $(GITHUB_TOKEN)" -H "Accept: application/vnd.github.v3.raw" https://raw.githubusercontent.com/$(BUILD_HARNESS_EXTENSIONS_ORG)/$(BUILD_HARNESS_EXTENSIONS_PROJECT)/$(BUILD_HARNESS_EXTENSIONS_BRANCH)/bin/install.sh | \
-		bash -s "$(BUILD_HARNESS_ORG)" "$(BUILD_HARNESS_PROJECT)" "$(BUILD_HARNESS_BRANCH)" "$(GITHUB_USER)" "$(GITHUB_TOKEN)"
-	@curl --retry 5 --fail --silent --retry-delay 1 -H "Authorization: token $(GITHUB_TOKEN)" -H "Accept: application/vnd.github.v3.raw" https://raw.githubusercontent.com/$(BUILD_HARNESS_EXTENSIONS_ORG)/$(BUILD_HARNESS_EXTENSIONS_PROJECT)/$(BUILD_HARNESS_EXTENSIONS_BRANCH)/bin/install-extensions.sh | \
-		bash -s "$(BUILD_HARNESS_EXTENSIONS_ORG)" "$(BUILD_HARNESS_EXTENSIONS_PROJECT)" "$(BUILD_HARNESS_EXTENSIONS_BRANCH)" "$(GITHUB_USER)" "$(GITHUB_TOKEN)"
+	@curl --retry 5 --fail --silent --retry-delay 1 -H "Accept: application/vnd.github.v3.raw" https://raw.githubusercontent.com/$(BUILD_HARNESS_EXTENSIONS_ORG)/$(BUILD_HARNESS_EXTENSIONS_PROJECT)/$(BUILD_HARNESS_EXTENSIONS_BRANCH)/bin/install.sh | \
+		bash -s "$(BUILD_HARNESS_ORG)" "$(BUILD_HARNESS_PROJECT)" "$(BUILD_HARNESS_BRANCH)" 
+	@curl --retry 5 --fail --silent --retry-delay 1 -H "Accept: application/vnd.github.v3.raw" https://raw.githubusercontent.com/$(BUILD_HARNESS_EXTENSIONS_ORG)/$(BUILD_HARNESS_EXTENSIONS_PROJECT)/$(BUILD_HARNESS_EXTENSIONS_BRANCH)/bin/install-extensions.sh | \
+		bash -s "$(BUILD_HARNESS_EXTENSIONS_ORG)" "$(BUILD_HARNESS_EXTENSIONS_PROJECT)" "$(BUILD_HARNESS_EXTENSIONS_BRANCH)" 
 
 .PHONY : clean
 ## Clean build-harness


### PR DESCRIPTION
can we remove tokens of build-harness-bootstrap, as build-harness is open source now