### PR TITLE
Patch OC_SOURCE_URL to use ocp subdirectory rather than the oc directory

### DIFF
--- a/modules/oc/Makefile
+++ b/modules/oc/Makefile
@@ -1,8 +1,8 @@
 # A simple build harness module to install the newest version of the oc cli.
 
 OC_BUILD_VERSION?=latest
-OC_PLATFORM ?= $(shell echo $(BUILD_HARNESS_OS) | sed 's/darwin/macosx/g')
-OC_SOURCE_URL?="https://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_BUILD_VERSION}/${OC_PLATFORM}/oc.tar.gz"
+OC_PLATFORM ?= $(shell echo $(BUILD_HARNESS_OS) | sed 's/darwin/mac/g')
+OC_SOURCE_URL?="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_BUILD_VERSION}/openshift-client-${OC_PLATFORM}.tar.gz"
 
 OC_DEST_PATH?=${BUILD_HARNESS_PATH}/vendor
 OC_TAR_PATH?=${OC_DEST_PATH}/oc.tar.gz


### PR DESCRIPTION
## Overview

Unbeknownst to us, the `oc` directory in https://mirror.openshift.com/pub/openshift-v4/clients/oc was taken to the woodshed... so we need to patch *everything*.  