### PR TITLE
Support GITHUB_USER and GITHUB_TOKEN Travis vars

### DIFF
--- a/modules/release-ff/bin/release_ff.sh
+++ b/modules/release-ff/bin/release_ff.sh
@@ -22,7 +22,7 @@ then
   echo "Using GITHUB_USER and GITHUB_TOKEN for authentication"
   REPO_URL=${REPO_URL/https:\/\//https:\/\/${GITHUB_USER}\:${GITHUB_TOKEN}@}
 fi
-git clone -b ${RELEASE_MAIN_BRANCH} ${REPO_URL} repo-copy
+git clone -b ${RELEASE_MAIN_BRANCH} "${REPO_URL}" repo-copy
 cd repo-copy
 if ! git checkout -b ${RELEASE_FF_BRANCH} origin/${RELEASE_FF_BRANCH}
 then

--- a/modules/release-ff/bin/release_ff.sh
+++ b/modules/release-ff/bin/release_ff.sh
@@ -16,7 +16,13 @@ then
 fi
 
 rm -rf repo-copy
-git clone -b ${RELEASE_MAIN_BRANCH} $(git remote get-url origin) repo-copy
+REPO_URL=$(git remote get-url origin)
+if [[ -n "$GITHUB_USER" && -n "$GITHUB_TOKEN" ]]
+then
+  echo "Using GITHUB_USER and GITHUB_TOKEN for authentication"
+  REPO_URL=${REPO_URL/https:\/\//https:\/\/${GITHUB_USER}\:${GITHUB_TOKEN}@}
+fi
+git clone -b ${RELEASE_MAIN_BRANCH} ${REPO_URL} repo-copy
 cd repo-copy
 if ! git checkout -b ${RELEASE_FF_BRANCH} origin/${RELEASE_FF_BRANCH}
 then


### PR DESCRIPTION
Updates the release-ff module to work with variables `GITHUB_USER` and `GITHUB_TOKEN`. This way an SSH key is not required (which is not possible in Travis for public repos).

An example in action using a copy of the updated script:
https://travis-ci.com/github/open-cluster-management/application-chart/jobs/485339301#L145

One potential issue is that if a repo already has `GITHUB_TOKEN` set up, but it is not an administrator token, `release-ff` will stop working. We could add a 3rd variable to opt in to token-based authentication.

