### PR TITLE
Change default bootstrap-ks branch from master to main

### DIFF
--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -1,6 +1,6 @@
 #-- bootstrap-ks Params---#
 BOOTSTRAP_KS_REPO ?= https://${GITHUB_TOKEN}@github.com/open-cluster-management/bootstrap-ks.git
-BOOTSTRAP_KS_BRANCH ?= master
+BOOTSTRAP_KS_BRANCH ?= main
 BOOTSTRAP_KS_DEPLOY_DIR ?= bootstrap-ks
 
 #---Login/Host-cluster related env vars---#


### PR DESCRIPTION
## Summary of Changes

Change the default bootstrap-ks branch name from master to main to accomodate changes in that repo.  