### PR TITLE
Add support for provisioning, saving as secrets, and getting metadata from ARO clusters via bootstrap-ks

### DIFF
--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -426,6 +426,7 @@ bootstrap-ks/aro-create-cluster: %aro-create-cluster: %aro-install
 .PHONY: bootstrap-ks/aro-save-secret
 ## Save ARO metadata as a secret.  You can filter these secrets using --selector=bootstrap-ks=true --bootstrap-ks-secret-type=aro
 bootstrap-ks/aro-save-secret: %aro-save-secret: %_init
+	$(call assert-set,BOOTSTRAP_KS_ARO_CLUSTER_NAME)
 	@$(SELF) -s oc/command OC_COMMAND="create secret generic $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) \
 		-n $(BOOTSTRAP_KS_HOST_NAMESPACE) \
 		--from-file=json=$(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json \
@@ -449,11 +450,8 @@ bootstrap-ks/aro-save-secret: %aro-save-secret: %_init
 bootstrap-ks/aro-delete-cluster: %aro-delete-cluster: %aro-install
 	$(call assert-set,AZURE_USER)
 	$(call assert-set,AZURE_PASS)
-	@if [ ! -z "$(BOOTSTRAP_KS_ARO_JSON_FILE)" ]; then \
-	  cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh ${BOOTSTRAP_KS_ARO_JSON_FILE}; \
-	else \
-		cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh *.json; \
-	fi;
+	$(call assert-set,BOOTSTRAP_KS_ARO_CLUSTER_NAME)
+	@cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh $(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json;
 
 
 ##======= Amazon Elastic Kubernetes Service ===========================

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -452,10 +452,7 @@ bootstrap-ks/aro-delete-cluster: %aro-delete-cluster: %aro-install
 	$(call assert-set,AZURE_USER)
 	$(call assert-set,AZURE_PASS)
 	$(call assert-set,BOOTSTRAP_KS_ARO_CLUSTER_NAME)
-	@${OC} get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json
-	@${OC} get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json | ${JQ} -r '.data'
 	@${OC} get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json | ${JQ} -r '.data.json' | base64 -d > ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
-	@cat ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
 	@cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh ${BUILD_HARNESS_PATH}/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json;
 
 

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -452,9 +452,9 @@ bootstrap-ks/aro-delete-cluster: %aro-delete-cluster: %aro-install
 	$(call assert-set,AZURE_USER)
 	$(call assert-set,AZURE_PASS)
 	$(call assert-set,BOOTSTRAP_KS_ARO_CLUSTER_NAME)
-	$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json"
-	$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json" | ${JQ} -r '.data'
-	$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json" | ${JQ} -r '.data["json"]' | base64 -d > ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
+	@${OC} get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json
+	@${OC} get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json | ${JQ} -r '.data'
+	@${OC} get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json | ${JQ} -r '.data.json' | base64 -d > ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
 	@cat ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
 	@cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh ${BUILD_HARNESS_PATH}/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json;
 

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -452,7 +452,7 @@ bootstrap-ks/aro-delete-cluster: %aro-delete-cluster: %aro-install
 	$(call assert-set,AZURE_USER)
 	$(call assert-set,AZURE_PASS)
 	$(call assert-set,BOOTSTRAP_KS_ARO_CLUSTER_NAME)
-	@cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh $(BOOTSTRAP_KS_ARO_CLUSTER_NAME).*.json;
+	@cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh $(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json;
 
 
 ##======= Amazon Elastic Kubernetes Service ===========================

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -54,7 +54,28 @@ bootstrap-ks/get-cluster-kubeconfig: %get-cluster-kubeconfig: %_init
 	$(call assert-set,BOOTSTRAP_KS_CLUSTER_NAME)
 	$(call assert-set,BOOTSTRAP_KS_HOST_API)
 	$(call assert-set,BOOTSTRAP_KS_HOST_NAMESPACE)
-	@$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_CLUSTER_NAME) -o json | $(JQ) -r .data.kubeconfig | base64 -d"
+	@$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_CLUSTER_NAME) -o json | $(JQ) -r .data.kubeconfig" > $(BUILD_HARNESS_PATH)/.tmp_kubeconfig
+	@if [[ `cat ${BUILD_HARNESS_PATH}/.tmp_kubeconfig` == "null" ]]; then \
+		$(SELF) -s bootstrap-ks/get-cluster-username BOOTSTRAP_KS_CLUSTER_NAME=$(BOOTSTRAP_KS_CLUSTER_NAME) BOOTSTRAP_KS_HOST_NAMESPACE=$(BOOTSTRAP_KS_HOST_NAMESPACE) > $(BUILD_HARNESS_PATH)/.kc_un; \
+		$(SELF) -s bootstrap-ks/get-cluster-password BOOTSTRAP_KS_CLUSTER_NAME=$(BOOTSTRAP_KS_CLUSTER_NAME) BOOTSTRAP_KS_HOST_NAMESPACE=$(BOOTSTRAP_KS_HOST_NAMESPACE) > $(BUILD_HARNESS_PATH)/.kc_pw; \
+		$(SELF) -s bootstrap-ks/get-cluster-api BOOTSTRAP_KS_CLUSTER_NAME=$(BOOTSTRAP_KS_CLUSTER_NAME) BOOTSTRAP_KS_HOST_NAMESPACE=$(BOOTSTRAP_KS_HOST_NAMESPACE) > $(BUILD_HARNESS_PATH)/.kc_api; \
+		if [[ "`cat $(BUILD_HARNESS_PATH)/.kc_un`" != "null" && "`cat $(BUILD_HARNESS_PATH)/.kc_pw`" != null && "`cat $(BUILD_HARNESS_PATH)/.kc_api`" != "null" ]]; then \
+			rm -f $(BUILD_HARNESS_PATH)/.tmp_kubeconfig; \
+			$(SELF) -s oc/install &> /dev/null; \
+			KUBECONFIG=$(BUILD_HARNESS_PATH)/.tmp_kubeconfig \
+				$(OC) login "`cat $(BUILD_HARNESS_PATH)/.kc_api`" \
+				--username="`cat $(BUILD_HARNESS_PATH)/.kc_un`" \
+				--password="`cat $(BUILD_HARNESS_PATH)/.kc_pw`" \
+				--insecure-skip-tls-verify=true &> /dev/null; \
+		else \
+			exit 1; \
+		fi; \
+	else \
+		cat $(BUILD_HARNESS_PATH)/.tmp_kubeconfig | base64 -d > $(BUILD_HARNESS_PATH)/.tmp_kc && mv $(BUILD_HARNESS_PATH)/.tmp_kc $(BUILD_HARNESS_PATH)/.tmp_kubeconfig; \
+	fi;
+	@cat $(BUILD_HARNESS_PATH)/.tmp_kubeconfig
+	@rm -f $(BUILD_HARNESS_PATH)/.tmp_kubeconfig $(BUILD_HARNESS_PATH)/.kc_api $(BUILD_HARNESS_PATH)/.kc_pw $(BUILD_HARNESS_PATH)/.kc_un &> /dev/null
+
 
 .PHONY: bootstrap-ks/get-cluster-username
 ## Get cluster username from secret
@@ -152,8 +173,7 @@ bootstrap-ks/get-cluster-metadata: %get-cluster-metadata:
 	$(call assert-set,BOOTSTRAP_KS_METADATA_FILE)
 	@$(SELF) -s bootstrap-ks/get-cluster-type > .ct
 	@$(SELF) -s bootstrap-ks/get-secret-type > .st
-	if [[ `cat .st` != "aro" ]]; then \
-		$(SELF) -s bootstrap-ks/get-cluster-kubeconfig > $(PWD)/$(BOOTSTRAP_KS_CLUSTER_NAME).kubeconfig; fi;
+	@$(SELF) -s bootstrap-ks/get-cluster-kubeconfig > $(PWD)/$(BOOTSTRAP_KS_CLUSTER_NAME).kubeconfig;
 	@if [[ `cat .ct` == "ocp" ]]; then \
 		$(SELF) -s bootstrap-ks/get-cluster-username > .un; \
 		$(SELF) -s bootstrap-ks/get-cluster-password > .pw;\
@@ -169,8 +189,7 @@ bootstrap-ks/get-cluster-metadata: %get-cluster-metadata:
 	@echo "{}" > gc1.json
 	@$(JQ) --arg type `cat .ct` '. + {type: $$type}' gc1.json > .tmp; mv .tmp gc1.json
 	@$(JQ) --arg secret_type `cat .st` '. + {secret_type: $$secret_type}' gc1.json > .tmp; mv .tmp gc1.json
-	if [[ `cat .st` != "aro" ]]; then \
-		$(JQ) --arg kubeconfig $(PWD)/$(BOOTSTRAP_KS_CLUSTER_NAME).kubeconfig '. + {kubeconfig: $$kubeconfig}' gc1.json > .tmp; mv .tmp gc1.json; fi;
+	@$(JQ) --arg kubeconfig $(PWD)/$(BOOTSTRAP_KS_CLUSTER_NAME).kubeconfig '. + {kubeconfig: $$kubeconfig}' gc1.json > .tmp; mv .tmp gc1.json;
 	@if [[ `cat .ct` == "ocp" ]]; then \
 		$(JQ) --arg username `cat .un` '. + {username: $$username}' gc1.json > .tmp; mv .tmp gc1.json; \
 		$(JQ) --arg password `cat .pw` '. + {password: $$password}' gc1.json > .tmp; mv .tmp gc1.json; \

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -437,7 +437,7 @@ bootstrap-ks/aro-save-secret: %aro-save-secret: %_init
 		--from-literal=azure_subscription_id=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.SUBSCRIPTION'` \
 		--from-literal=cloud_platform=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.PLATFORM'` \
 		--from-literal=azure_base_domain_resource_group_name=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.AZURE_BASE_DOMAIN_RESOURCE_GROUP_NAME'` \
-		--from-literal=basedomain=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.AZURE_BASE_DOMAIN'` \
+		--from-literal=basedomain=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.CLUSTER_NAME'`.`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.AZURE_BASE_DOMAIN'` \
 		--from-literal=username=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.USERNAME'` \
 		--from-literal=password=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.PASSWORD'` \
 		--from-literal=console_url=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.CONSOLE_URL'` \

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -452,8 +452,9 @@ bootstrap-ks/aro-delete-cluster: %aro-delete-cluster: %aro-install
 	$(call assert-set,AZURE_USER)
 	$(call assert-set,AZURE_PASS)
 	$(call assert-set,BOOTSTRAP_KS_ARO_CLUSTER_NAME)
-	@$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json" | ${JQ} -r '.data["json"]'
-	@$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json" | ${JQ} -r '.data["json"]' | base64 -d > ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
+	$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json"
+	$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json" | ${JQ} -r '.data'
+	$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json" | ${JQ} -r '.data["json"]' | base64 -d > ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
 	@cat ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
 	@cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh ${BUILD_HARNESS_PATH}/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json;
 

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -452,7 +452,7 @@ bootstrap-ks/aro-delete-cluster: %aro-delete-cluster: %aro-install
 	$(call assert-set,AZURE_USER)
 	$(call assert-set,AZURE_PASS)
 	$(call assert-set,BOOTSTRAP_KS_ARO_CLUSTER_NAME)
-	@cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh $(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json;
+	@cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh $(BOOTSTRAP_KS_ARO_CLUSTER_NAME).*.json;
 
 
 ##======= Amazon Elastic Kubernetes Service ===========================

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -28,6 +28,7 @@ BOOTSTRAP_KS_GKE_CLUSTER_NAME = $(shell cat ${BOOTSTRAP_KS_DEPLOY_DIR}/gke/*.jso
 BOOTSTRAP_KS_EKS_CLUSTER_NAME = $(shell cat ${BOOTSTRAP_KS_DEPLOY_DIR}/eks/*.json | $(JQ) -r .CLUSTER_NAME)
 BOOTSTRAP_KS_IKS_CLUSTER_NAME = $(shell cat ${BOOTSTRAP_KS_DEPLOY_DIR}/iks/*-iks.json | $(JQ) -r .CLUSTER_NAME)
 BOOTSTRAP_KS_ROKS_CLUSTER_NAME = $(shell cat ${BOOTSTRAP_KS_DEPLOY_DIR}/iks/*-roks.json | $(JQ) -r .CLUSTER_NAME)
+BOOTSTRAP_KS_ARO_CLUSTER_NAME ?= ${BOOTSTRAP_KS_CLUSTER_NAME}
 
 # Convenience to just call bare jq executable
 JQ ?= $(BUILD_HARNESS_PATH)/vendor/jq

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -120,6 +120,14 @@ bootstrap-ks/get-cluster-cloud-platform: %get-cluster-cloud-platform: %_init
 	$(call assert-set,BOOTSTRAP_KS_HOST_NAMESPACE)
 	@$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_CLUSTER_NAME) -o json | $(JQ) -r .data.cloud_platform | base64 -d"
 
+.PHONY: bootstrap-ks/get-cluster-json
+## Get cluster cloud-platform from secret
+bootstrap-ks/get-cluster-json: %get-cluster-json: %_init
+	$(call assert-set,BOOTSTRAP_KS_CLUSTER_NAME)
+	$(call assert-set,BOOTSTRAP_KS_HOST_API)
+	$(call assert-set,BOOTSTRAP_KS_HOST_NAMESPACE)
+	@$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_CLUSTER_NAME) -o json | $(JQ) -r .data.json | base64 -d"
+
 .PHONY: bootstrap-ks/get-cluster-type
 ## Get cluster type from secret
 bootstrap-ks/get-cluster-type: %get-cluster-type: %_init
@@ -144,29 +152,35 @@ bootstrap-ks/get-cluster-metadata: %get-cluster-metadata:
 	$(call assert-set,BOOTSTRAP_KS_METADATA_FILE)
 	@$(SELF) -s bootstrap-ks/get-cluster-type > .ct
 	@$(SELF) -s bootstrap-ks/get-secret-type > .st
-	@$(SELF) -s bootstrap-ks/get-cluster-kubeconfig > $(PWD)/$(BOOTSTRAP_KS_CLUSTER_NAME).kubeconfig
-	@if [[ `cat .st` == "clusterclaim" ]]; then \
+	if [[ `cat .st` != "aro" ]]; then \
+		$(SELF) -s bootstrap-ks/get-cluster-kubeconfig > $(PWD)/$(BOOTSTRAP_KS_CLUSTER_NAME).kubeconfig; fi;
+	@if [[ `cat .ct` == "ocp" ]]; then \
 		$(SELF) -s bootstrap-ks/get-cluster-username > .un; \
 		$(SELF) -s bootstrap-ks/get-cluster-password > .pw;\
 		$(SELF) -s bootstrap-ks/get-cluster-api > .api; \
-		$(SELF) -s bootstrap-ks/get-cluster-claim > .cc; \
 		$(SELF) -s bootstrap-ks/get-cluster-basedomain > .bd; \
 		$(SELF) -s bootstrap-ks/get-cluster-cloud-platform > .pf; \
-		$(SELF) -s bootstrap-ks/get-cluster-claim > .ccns; \
 		$(SELF) -s bootstrap-ks/get-cluster-console > .con; fi;
+	@if [[ `cat .st` == "clusterclaim" ]]; then \
+		$(SELF) -s bootstrap-ks/get-cluster-claim > .cc; \
+		$(SELF) -s bootstrap-ks/get-cluster-claim > .ccns; fi;
+	@if [[ `cat .st` == "aro" ]]; then \
+		$(SELF) -s bootstrap-ks/get-cluster-json > ${BOOTSTRAP_KS_METADATA_FILE}.aro.raw.json; fi;
 	@echo "{}" > gc1.json
 	@$(JQ) --arg type `cat .ct` '. + {type: $$type}' gc1.json > .tmp; mv .tmp gc1.json
 	@$(JQ) --arg secret_type `cat .st` '. + {secret_type: $$secret_type}' gc1.json > .tmp; mv .tmp gc1.json
-	@$(JQ) --arg kubeconfig $(PWD)/$(BOOTSTRAP_KS_CLUSTER_NAME).kubeconfig '. + {kubeconfig: $$kubeconfig}' gc1.json > .tmp; mv .tmp gc1.json
-	@if [[ `cat .st` == "clusterclaim" ]]; then \
+	if [[ `cat .st` != "aro" ]]; then \
+		$(JQ) --arg kubeconfig $(PWD)/$(BOOTSTRAP_KS_CLUSTER_NAME).kubeconfig '. + {kubeconfig: $$kubeconfig}' gc1.json > .tmp; mv .tmp gc1.json; fi;
+	@if [[ `cat .ct` == "ocp" ]]; then \
 		$(JQ) --arg username `cat .un` '. + {username: $$username}' gc1.json > .tmp; mv .tmp gc1.json; \
 		$(JQ) --arg password `cat .pw` '. + {password: $$password}' gc1.json > .tmp; mv .tmp gc1.json; \
 		$(JQ) --arg api_url `cat .api` '. + {api_url: $$api_url}' gc1.json > .tmp; mv .tmp gc1.json; \
 		$(JQ) --arg basedomain `cat .bd` '. + {basedomain: $$basedomain}' gc1.json > .tmp; mv .tmp gc1.json; \
-		$(JQ) --arg clusterclaim `cat .cc` '. + {clusterclaim: $$clusterclaim}' gc1.json > .tmp; mv .tmp gc1.json; \
 		$(JQ) --arg cloudplatform `cat .pf` '. + {cloud_platform: $$cloudplatform}' gc1.json > .tmp; mv .tmp gc1.json; \
-		$(JQ) --arg clusterclaim_namespace `cat .ccns` '. + {clusterclaim_namespace: $$clusterclaim_namespace}' gc1.json > .tmp; mv .tmp gc1.json; \
 		$(JQ) --arg console_url `cat .con` '. + {console_url: $$console_url}' gc1.json > .tmp; mv .tmp gc1.json; fi;
+	@if [[ `cat .st` == "clusterclaim" ]]; then \
+		$(JQ) --arg clusterclaim `cat .cc` '. + {clusterclaim: $$clusterclaim}' gc1.json > .tmp; mv .tmp gc1.json; \
+		$(JQ) --arg clusterclaim_namespace `cat .ccns` '. + {clusterclaim_namespace: $$clusterclaim_namespace}' gc1.json > .tmp; mv .tmp gc1.json; fi;
 	@cat gc1.json > $(BOOTSTRAP_KS_METADATA_FILE)
 	@rm -f .ct .st .cc .pf .ccns .un .pw .api .con gc1.json
 	@cat $(BOOTSTRAP_KS_METADATA_FILE)
@@ -307,6 +321,7 @@ bootstrap-ks/clusterclaim-delete-cluster: %clusterclaim-delete-cluster: %_init
 	$(call assert-set,BOOTSTRAP_KS_CC_NAMESPACE)
 	@$(SELF) -s oc/command OC_COMMAND="delete clusterclaim -n $(BOOTSTRAP_KS_CC_NAMESPACE) $(BOOTSTRAP_KS_CC_NAME)"
 
+
 ##======= Azure Kubernetes Service ===========================
 
 .PHONY: bootstrap-ks/aks-install
@@ -361,6 +376,62 @@ bootstrap-ks/aks-delete-cluster: %aks-delete-cluster: %aks-install
 	  cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aks; ./destroy.sh ${BOOTSTRAP_KS_AKS_JSON_FILE}; \
 	else \
 		cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aks; ./destroy.sh *.json; \
+	fi;
+
+
+##======= Azure Red Hat Openshift ===========================
+
+.PHONY: bootstrap-ks/aro-install
+## Install Azure Red Hat OpenShift (ARO) cluster
+bootstrap-ks/aro-install: %aro-install: %_init
+	@cd $(BOOTSTRAP_KS_DEPLOY_DIR)/aro; ./install.sh;
+
+.PHONY: bootstrap-ks/aro-create-cluster
+## Create Azure Red Hat OpenShift (ARO) cluster
+bootstrap-ks/aro-create-cluster: %aro-create-cluster: %aro-install
+	$(call assert-set,AZURE_USER)
+	$(call assert-set,AZURE_PASS)
+	$(call assert-set,BOOTSTRAP_KS_ARO_CLUSTER_NAME)
+	$(call assert-set,AZURE_BASE_DOMAIN_RESOURCE_GROUP_NAME)
+	$(call assert-set,AZURE_BASE_DOMAIN)
+	$(call assert-set,OCP_PULL_SECRET_FILE)
+	@cd $(BOOTSTRAP_KS_DEPLOY_DIR)/aro; \
+		CLUSTER_NAME=${BOOTSTRAP_KS_ARO_CLUSTER_NAME} \
+		AZURE_BASE_DOMAIN_RESOURCE_GROUP_NAME=${AZURE_BASE_DOMAIN_RESOURCE_GROUP_NAME} \
+		AZURE_BASE_DOMAIN=${AZURE_BASE_DOMAIN} \
+		OCP_PULL_SECRET_FILE=${OCP_PULL_SECRET_FILE} \
+		./provision.sh;
+
+.PHONY: bootstrap-ks/aro-save-secret
+## Save ARO metadata as a secret.  You can filter these secrets using --selector=bootstrap-ks=true --bootstrap-ks-secret-type=aro
+bootstrap-ks/aro-save-secret: %aro-save-secret: %_init
+	@$(SELF) -s oc/command OC_COMMAND="create secret generic $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) \
+		-n $(BOOTSTRAP_KS_HOST_NAMESPACE) \
+		--from-file=json=$(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json \
+		--from-literal=resource_group_name=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.RESOURCE_GROUP_NAME'` \
+		--from-literal=cluster_name=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.CLUSTER_NAME'` \
+		--from-literal=region=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.REGION'` \
+		--from-literal=azure_subscription_id=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.SUBSCRIPTION'` \
+		--from-literal=cloud_platform=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.PLATFORM'` \
+		--from-literal=azure_base_domain_resource_group_name=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.AZURE_BASE_DOMAIN_RESOURCE_GROUP_NAME'` \
+		--from-literal=basedomain=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.AZURE_BASE_DOMAIN'` \
+		--from-literal=username=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.USERNAME'` \
+		--from-literal=password=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.PASSWORD'` \
+		--from-literal=console_url=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.CONSOLE_URL'` \
+		--from-literal=api_url=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.API_URL'`"
+	@$(SELF) -s oc/command OC_COMMAND="label secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) bootstrap-ks=true"
+	@$(SELF) -s oc/command OC_COMMAND="label secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) bootstrap-ks-type=ocp"
+	@$(SELF) -s oc/command OC_COMMAND="label secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) bootstrap-ks-secret-type=aro"
+
+.PHONY: bootstrap-ks/aro-delete-cluster
+## Delete Azure Red Hat OpenShift cluster. OPTIONAL: BOOTSTRAP_KS_AKS_JSON_FILE - path to the json file for the ARO instance
+bootstrap-ks/aro-delete-cluster: %aro-delete-cluster: %aro-install
+	$(call assert-set,AZURE_USER)
+	$(call assert-set,AZURE_PASS)
+	@if [ ! -z "$(BOOTSTRAP_KS_ARO_JSON_FILE)" ]; then \
+	  cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh ${BOOTSTRAP_KS_ARO_JSON_FILE}; \
+	else \
+		cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh *.json; \
 	fi;
 
 

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -452,8 +452,8 @@ bootstrap-ks/aro-delete-cluster: %aro-delete-cluster: %aro-install
 	$(call assert-set,AZURE_USER)
 	$(call assert-set,AZURE_PASS)
 	$(call assert-set,BOOTSTRAP_KS_ARO_CLUSTER_NAME)
-	@$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json"
-	@$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json" | ${JQ} -r '.data.json' | base64 -d > ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
+	@$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json" | ${JQ} -r '.data["json"]'
+	@$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json" | ${JQ} -r '.data["json"]' | base64 -d > ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
 	@cat ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
 	@cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh ${BUILD_HARNESS_PATH}/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json;
 

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -225,6 +225,8 @@ bootstrap-ks/delete-cluster: %delete-cluster: %_init
 		$(SELF) boostrap-ks/roks-delete-cluster; \
 	elif [[ `cat .st` == "gke" ]]; then \
 		$(SELF) boostrap-ks/gke-delete-cluster; \
+	elif [[ `cat .st` == "aro" ]]; then \
+		$(SELF) boostrap-ks/aro-delete-cluster; \
 	fi;
 
 .PHONY: bootstrap-ks/delete-secret

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -212,7 +212,6 @@ bootstrap-ks/delete-cluster: %delete-cluster: %_init
 	$(call assert-set,BOOTSTRAP_KS_HOST_API)
 	$(call assert-set,BOOTSTRAP_KS_HOST_NAMESPACE)
 	@$(SELF) -s bootstrap-ks/get-secret-type > .st
-	@echo "`cat .st`";
 	@if [[ `cat .st` == "clusterclaim" ]]; then \
 		$(SELF) bootstrap-ks/clusterclaim-delete-cluster \
 			BOOTSTRAP_KS_CC_NAME=`$(SELF) -s bootstrap-ks/get-cluster-claim` \
@@ -453,6 +452,7 @@ bootstrap-ks/aro-delete-cluster: %aro-delete-cluster: %aro-install
 	$(call assert-set,AZURE_USER)
 	$(call assert-set,AZURE_PASS)
 	$(call assert-set,BOOTSTRAP_KS_ARO_CLUSTER_NAME)
+	@$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json"
 	@$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json" | ${JQ} -r '.data.json' | base64 -d > ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
 	@cat ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
 	@cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh ${BUILD_HARNESS_PATH}/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json;

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -431,17 +431,17 @@ bootstrap-ks/aro-save-secret: %aro-save-secret: %_init
 	@$(SELF) -s oc/command OC_COMMAND="create secret generic $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) \
 		-n $(BOOTSTRAP_KS_HOST_NAMESPACE) \
 		--from-file=json=$(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json \
-		--from-literal=resource_group_name=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.RESOURCE_GROUP_NAME'` \
-		--from-literal=cluster_name=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.CLUSTER_NAME'` \
-		--from-literal=region=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.REGION'` \
-		--from-literal=azure_subscription_id=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.SUBSCRIPTION'` \
-		--from-literal=cloud_platform=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.PLATFORM'` \
-		--from-literal=azure_base_domain_resource_group_name=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.AZURE_BASE_DOMAIN_RESOURCE_GROUP_NAME'` \
-		--from-literal=basedomain=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.CLUSTER_NAME'`.`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.AZURE_BASE_DOMAIN'` \
-		--from-literal=username=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.USERNAME'` \
-		--from-literal=password=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.PASSWORD'` \
-		--from-literal=console_url=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.CONSOLE_URL'` \
-		--from-literal=api_url=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | jq -r '.API_URL'`"
+		--from-literal=resource_group_name=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | ${JQ} -r '.RESOURCE_GROUP_NAME'` \
+		--from-literal=cluster_name=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | ${JQ} -r '.CLUSTER_NAME'` \
+		--from-literal=region=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | ${JQ} -r '.REGION'` \
+		--from-literal=azure_subscription_id=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | ${JQ} -r '.SUBSCRIPTION'` \
+		--from-literal=cloud_platform=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | ${JQ} -r '.PLATFORM'` \
+		--from-literal=azure_base_domain_resource_group_name=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | ${JQ} -r '.AZURE_BASE_DOMAIN_RESOURCE_GROUP_NAME'` \
+		--from-literal=basedomain=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | ${JQ} -r '.CLUSTER_NAME'`.`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | ${JQ} -r '.AZURE_BASE_DOMAIN'` \
+		--from-literal=username=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | ${JQ} -r '.USERNAME'` \
+		--from-literal=password=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | ${JQ} -r '.PASSWORD'` \
+		--from-literal=console_url=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | ${JQ} -r '.CONSOLE_URL'` \
+		--from-literal=api_url=`cat $(BOOTSTRAP_KS_DEPLOY_DIR)/aro/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json | ${JQ} -r '.API_URL'`"
 	@$(SELF) -s oc/command OC_COMMAND="label secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) bootstrap-ks=true"
 	@$(SELF) -s oc/command OC_COMMAND="label secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) bootstrap-ks-type=ocp"
 	@$(SELF) -s oc/command OC_COMMAND="label secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) bootstrap-ks-secret-type=aro"
@@ -452,7 +452,8 @@ bootstrap-ks/aro-delete-cluster: %aro-delete-cluster: %aro-install
 	$(call assert-set,AZURE_USER)
 	$(call assert-set,AZURE_PASS)
 	$(call assert-set,BOOTSTRAP_KS_ARO_CLUSTER_NAME)
-	@cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh $(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json;
+	@$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json" | ${JQ} -r '.data.json' | base64 -d > ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
+	@cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh ${BUILD_HARNESS_PATH}/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json;
 
 
 ##======= Amazon Elastic Kubernetes Service ===========================

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -212,6 +212,7 @@ bootstrap-ks/delete-cluster: %delete-cluster: %_init
 	$(call assert-set,BOOTSTRAP_KS_HOST_API)
 	$(call assert-set,BOOTSTRAP_KS_HOST_NAMESPACE)
 	@$(SELF) -s bootstrap-ks/get-secret-type > .st
+	@echo "`cat .st`";
 	@if [[ `cat .st` == "clusterclaim" ]]; then \
 		$(SELF) bootstrap-ks/clusterclaim-delete-cluster \
 			BOOTSTRAP_KS_CC_NAME=`$(SELF) -s bootstrap-ks/get-cluster-claim` \

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -217,17 +217,17 @@ bootstrap-ks/delete-cluster: %delete-cluster: %_init
 			BOOTSTRAP_KS_CC_NAME=`$(SELF) -s bootstrap-ks/get-cluster-claim` \
 			BOOTSTRAP_KS_CC_NAMESPACE=`$(SELF) -s bootstrap-ks/get-cluster-claim-namespace`; \
 	elif [[ `cat .st` == "aks" ]]; then \
-		$(SELF) boostrap-ks/aks-delete-cluster; \
+		$(SELF) bootstrap-ks/aks-delete-cluster; \
 	elif [[ `cat .st` == "eks" ]]; then \
-		$(SELF) boostrap-ks/eks-delete-cluster; \
+		$(SELF) bootstrap-ks/eks-delete-cluster; \
 	elif [[ `cat .st` == "iks" ]]; then \
-		$(SELF) boostrap-ks/iks-delete-cluster; \
+		$(SELF) bootstrap-ks/iks-delete-cluster; \
 	elif [[ `cat .st` == "roks" ]]; then \
-		$(SELF) boostrap-ks/roks-delete-cluster; \
+		$(SELF) bootstrap-ks/roks-delete-cluster; \
 	elif [[ `cat .st` == "gke" ]]; then \
-		$(SELF) boostrap-ks/gke-delete-cluster; \
+		$(SELF) bootstrap-ks/gke-delete-cluster; \
 	elif [[ `cat .st` == "aro" ]]; then \
-		$(SELF) boostrap-ks/aro-delete-cluster; \
+		$(SELF) bootstrap-ks/aro-delete-cluster; \
 	fi;
 
 .PHONY: bootstrap-ks/delete-secret

--- a/modules/bootstrap-ks/Makefile
+++ b/modules/bootstrap-ks/Makefile
@@ -227,7 +227,7 @@ bootstrap-ks/delete-cluster: %delete-cluster: %_init
 	elif [[ `cat .st` == "gke" ]]; then \
 		$(SELF) bootstrap-ks/gke-delete-cluster; \
 	elif [[ `cat .st` == "aro" ]]; then \
-		$(SELF) bootstrap-ks/aro-delete-cluster; \
+		$(SELF) bootstrap-ks/aro-delete-cluster BOOTSTRAP_KS_CLUSTER_NAME=$(BOOTSTRAP_KS_CLUSTER_NAME); \
 	fi;
 
 .PHONY: bootstrap-ks/delete-secret
@@ -453,6 +453,7 @@ bootstrap-ks/aro-delete-cluster: %aro-delete-cluster: %aro-install
 	$(call assert-set,AZURE_PASS)
 	$(call assert-set,BOOTSTRAP_KS_ARO_CLUSTER_NAME)
 	@$(SELF) -s oc/command OC_COMMAND="get secret -n $(BOOTSTRAP_KS_HOST_NAMESPACE) $(BOOTSTRAP_KS_ARO_CLUSTER_NAME) -o json" | ${JQ} -r '.data.json' | base64 -d > ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
+	@cat ${BUILD_HARNESS_PATH}/${BOOTSTRAP_KS_ARO_CLUSTER_NAME}.json
 	@cd ${BOOTSTRAP_KS_DEPLOY_DIR}/aro; ./destroy.sh ${BUILD_HARNESS_PATH}/$(BOOTSTRAP_KS_ARO_CLUSTER_NAME).json;
 
 


### PR DESCRIPTION
## Summary of Changes

This PR adds 3 ARO-specific targets:
* `bootstrap-ks/aro-install` - deploys an ARO cluster using [bootstrap-ks](https://github.com/open-cluster-management/bootstrap-ks)
* `bootstrap-ks/aro-save-secret` - save an ARO cluster provisioned by [bootstrap-ks](https://github.com/open-cluster-management/bootstrap-ks) as a secret on a kubernetes cluster
* `bootstrap-ks/aro-delete-cluster` - destroys an ARO cluster provisioned by [bootstrap-ks](https://github.com/open-cluster-management/bootstrap-ks)

This PR also adds another target to get a new field in the ARO secret:
* `bootstrap-ks/get-cluster-json` - gets the json field value from a secret

This PR also updates a few targets:
* `bootstrap-ks/get-cluster-kubeconfig` will now generate a kubeconfig by logging in with credentials if no kubeconfig is in the secret (note - this is a temporary kubeconfig but will do for our use-case) and fail if both kubeconfig and credentials are missing.
* `bootstrap-ks/get-cluster-metadata` will now tolerate clusterclaim, aro, and *ks type secrets
* `bootstrap-ks/clusterclaim-delete-cluster` will now conditionally delete an ARO cluster as passed