### PR TITLE
Add auto import toggle to checkout, defaulting to false

### DIFF
--- a/modules/clusterpool/Makefile
+++ b/modules/clusterpool/Makefile
@@ -75,6 +75,9 @@ CLUSTERPOOL_GCP_ACCOUNT_JSON_FILE ?= $(HOME)/.gcp/osServiceAccount.json
 #---Clusterpool List-related env vars---#
 CLUSTERPOOL_LIST_ARGUMENTS ?= 
 
+#---Clusterpool auto-import flag (true/false)---#
+CLUSTERPOOL_AUTO_IMPORT ?= "false"
+
 # Convenience to just call bare jq executable
 JQ ?= $(BUILD_HARNESS_PATH)/vendor/jq
 
@@ -310,11 +313,13 @@ clusterpool/_create-claim: %_create-claim: %_init
 			-e "s;__CLUSTERPOOL_NAME__;$(CLUSTERPOOL_NAME);g" \
 			-e "s;__CLUSTERPOOL_LIFETIME__;$(CLUSTERPOOL_LIFETIME);g" \
 			-e "s;__CLUSTERPOOL_GROUP_NAME__;$(CLUSTERPOOL_GROUP_NAME);g" \
+			-e "s;__CLUSTERPOOL_AUTO_IMPORT__;$(CLUSTERPOOL_AUTO_IMPORT);g" \
 			$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterclaim.yaml.template > $(BUILD_HARNESS_EXTENSIONS_PATH)/clusterclaim.yaml; else \
 		sed -e "s;__CLUSTERPOOL_CLUSTER_CLAIM__;$(CLUSTERPOOL_CLUSTER_CLAIM);g" \
 			-e "s;__CLUSTERPOOL_HOST_NAMESPACE__;$(CLUSTERPOOL_HOST_NAMESPACE);g" \
 			-e "s;__CLUSTERPOOL_NAME__;$(CLUSTERPOOL_NAME);g" \
 			-e "s;__CLUSTERPOOL_GROUP_NAME__;$(CLUSTERPOOL_GROUP_NAME);g" \
+			-e "s;__CLUSTERPOOL_AUTO_IMPORT__;$(CLUSTERPOOL_AUTO_IMPORT);g" \
 			$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterclaim.nolifetime.yaml.template > $(BUILD_HARNESS_EXTENSIONS_PATH)/clusterclaim.yaml; fi; \
 	if [ "`cat .whoami.txt | awk -F ':' '{print $$2}'`" == "serviceaccount" ]; then \
 		sed -e "s;__RBAC_SERVICEACCOUNT_NAME__;`cat .whoami.txt | awk -F ':' '{print $$4}'`;g" \

--- a/modules/clusterpool/templates/clusterclaim.nolifetime.yaml.template
+++ b/modules/clusterpool/templates/clusterclaim.nolifetime.yaml.template
@@ -3,6 +3,8 @@ kind: ClusterClaim
 metadata:
   name: __CLUSTERPOOL_CLUSTER_CLAIM__
   namespace: __CLUSTERPOOL_HOST_NAMESPACE__
+  annotations:
+    open-cluster-management.io/createmanagedcluster: "__CLUSTERPOOL_AUTO_IMPORT__"
 spec:
   clusterPoolName: __CLUSTERPOOL_NAME__
   subjects:

--- a/modules/clusterpool/templates/clusterclaim.yaml.template
+++ b/modules/clusterpool/templates/clusterclaim.yaml.template
@@ -3,6 +3,8 @@ kind: ClusterClaim
 metadata:
   name: __CLUSTERPOOL_CLUSTER_CLAIM__
   namespace: __CLUSTERPOOL_HOST_NAMESPACE__
+  annotations:
+    open-cluster-management.io/createmanagedcluster: "__CLUSTERPOOL_AUTO_IMPORT__"
 spec:
   clusterPoolName: __CLUSTERPOOL_NAME__
   lifetime: __CLUSTERPOOL_LIFETIME__


### PR DESCRIPTION
## Summary of Changes

To adapt to the auto-import claimed clusters from ACM 2.4, we need to include the flag to disable auto-import, and a way to set it!  

We'll default to false!