### PR TITLE
Correct the annotation used to skip auto-import on clusterclaim

### DIFF
--- a/modules/clusterpool/templates/clusterclaim.nolifetime.yaml.template
+++ b/modules/clusterpool/templates/clusterclaim.nolifetime.yaml.template
@@ -4,7 +4,7 @@ metadata:
   name: __CLUSTERPOOL_CLUSTER_CLAIM__
   namespace: __CLUSTERPOOL_HOST_NAMESPACE__
   annotations:
-    open-cluster-management.io/createmanagedcluster: "__CLUSTERPOOL_AUTO_IMPORT__"
+    cluster.open-cluster-management.io/createmanagedcluster: "__CLUSTERPOOL_AUTO_IMPORT__"
 spec:
   clusterPoolName: __CLUSTERPOOL_NAME__
   subjects:

--- a/modules/clusterpool/templates/clusterclaim.yaml.template
+++ b/modules/clusterpool/templates/clusterclaim.yaml.template
@@ -4,7 +4,7 @@ metadata:
   name: __CLUSTERPOOL_CLUSTER_CLAIM__
   namespace: __CLUSTERPOOL_HOST_NAMESPACE__
   annotations:
-    open-cluster-management.io/createmanagedcluster: "__CLUSTERPOOL_AUTO_IMPORT__"
+    cluster.open-cluster-management.io/createmanagedcluster: "__CLUSTERPOOL_AUTO_IMPORT__"
 spec:
   clusterPoolName: __CLUSTERPOOL_NAME__
   lifetime: __CLUSTERPOOL_LIFETIME__


### PR DESCRIPTION
## Summary of Changes

This PR fixes the annotation used to skip ACM 2.4's auto-import (disabling auto-import by default to avoid breaking changes).  