### PR TITLE
fix: copy files after pull to prevent conflicts

### DIFF
--- a/modules/pipeline-manifest/Makefile
+++ b/modules/pipeline-manifest/Makefile
@@ -256,10 +256,10 @@ pipeline-manifest/_snapshot-staging: %_snapshot-staging: %_clone
 pipeline-manifest/_snapshot: %_snapshot: %_clone %_validate-tag
 	@cp $(PIPELINE_MANIFEST_FILE_NAME)-$(TAG)-$(PIPELINE_MANIFEST_SHA_RELEASE_VERSION).json $(PIPELINE_MANIFEST_DIR)/$(PIPELINE_MANIFEST_SNAPSHOT_FOLDER)
 	@echo Preemptive pipeline git pull
-	@cd $(PIPELINE_MANIFEST_DIR); $(GIT) pull
-	@cd $(PIPELINE_MANIFEST_DIR); $(GIT) add $(PIPELINE_MANIFEST_SNAPSHOT_FOLDER)/$(PIPELINE_MANIFEST_FILE_NAME)-$(TAG)-$(PIPELINE_MANIFEST_SHA_RELEASE_VERSION).json
-	@cd $(PIPELINE_MANIFEST_DIR); $(GIT) commit -am "Added $(PIPELINE_MANIFEST_SHA_RELEASE_VERSION) snapshot of $(TAG) for $(PIPELINE_MANIFEST_COMPONENT)" --quiet
-	@cd $(PIPELINE_MANIFEST_DIR); $(GIT) push --quiet
+	@$(GIT) -C $(PIPELINE_MANIFEST_DIR) pull
+	@$(GIT) -C $(PIPELINE_MANIFEST_DIR) add $(PIPELINE_MANIFEST_SNAPSHOT_FOLDER)/$(PIPELINE_MANIFEST_FILE_NAME)-$(TAG)-$(PIPELINE_MANIFEST_SHA_RELEASE_VERSION).json
+	@$(GIT) -C $(PIPELINE_MANIFEST_DIR) commit -am "Added $(PIPELINE_MANIFEST_SHA_RELEASE_VERSION) snapshot of $(TAG) for $(PIPELINE_MANIFEST_COMPONENT)" --quiet
+	@$(GIT) -C $(PIPELINE_MANIFEST_DIR) push --quiet
 
 .PHONY: pipeline-manifest/_validate-tag
 # Create sha-based manifest (validates as it goes, fails if all images are not present)

--- a/modules/pipeline-manifest/Makefile
+++ b/modules/pipeline-manifest/Makefile
@@ -254,9 +254,9 @@ pipeline-manifest/_snapshot-staging: %_snapshot-staging: %_clone
 .PHONY: pipeline-manifest/_snapshot
 # Create snapshot of current repo.
 pipeline-manifest/_snapshot: %_snapshot: %_clone %_validate-tag
-	@cp $(PIPELINE_MANIFEST_FILE_NAME)-$(TAG)-$(PIPELINE_MANIFEST_SHA_RELEASE_VERSION).json $(PIPELINE_MANIFEST_DIR)/$(PIPELINE_MANIFEST_SNAPSHOT_FOLDER)
 	@echo Preemptive pipeline git pull
 	@$(GIT) -C $(PIPELINE_MANIFEST_DIR) pull
+	@cp $(PIPELINE_MANIFEST_FILE_NAME)-$(TAG)-$(PIPELINE_MANIFEST_SHA_RELEASE_VERSION).json $(PIPELINE_MANIFEST_DIR)/$(PIPELINE_MANIFEST_SNAPSHOT_FOLDER)
 	@$(GIT) -C $(PIPELINE_MANIFEST_DIR) add $(PIPELINE_MANIFEST_SNAPSHOT_FOLDER)/$(PIPELINE_MANIFEST_FILE_NAME)-$(TAG)-$(PIPELINE_MANIFEST_SHA_RELEASE_VERSION).json
 	@$(GIT) -C $(PIPELINE_MANIFEST_DIR) commit -am "Added $(PIPELINE_MANIFEST_SHA_RELEASE_VERSION) snapshot of $(TAG) for $(PIPELINE_MANIFEST_COMPONENT)" --quiet
 	@$(GIT) -C $(PIPELINE_MANIFEST_DIR) push --quiet


### PR DESCRIPTION
```
Preemptive pipeline git pull
From https://github.com/stolostron/pipeline
   5f7f886cad..f209ff8de1  2.15-integration -> origin/2.15-integration
error: The following untracked working tree files would be overwritten by merge:
Updating 5f7f886cad..f209ff8de1
	snapshots/manifest-2026-02-16-16-32-31-2.15.0.json
Please move or remove them before you merge.
Aborting
```

ref: https://github.com/stolostron/pipeline/actions/runs/22070646607/job/63774025348#step:4:589